### PR TITLE
Update solidus_support to `~> 0.5` and fix specs

### DIFF
--- a/app/decorators/models/solidus_shipping_labeler/spree/address_decorator.rb
+++ b/app/decorators/models/solidus_shipping_labeler/spree/address_decorator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Spree::Address.class_eval do
+module SolidusShippingLabeler::Spree::AddressDecorator
   def fedex_formatted
     {
       name: full_name,
@@ -14,4 +14,6 @@ Spree::Address.class_eval do
       residential: false, # going commercial to get access to FedEx Ground
     }
   end
+
+  Spree::Address.prepend self
 end

--- a/app/decorators/models/solidus_shipping_labeler/spree/return_authorization_decorator.rb
+++ b/app/decorators/models/solidus_shipping_labeler/spree/return_authorization_decorator.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-Spree::ReturnAuthorization.class_eval do
-  has_many :return_labels, class_name: "Spree::ReturnLabel"
+module SolidusShippingLabeler::Spree::ReturnAuthorizationDecorator
+  def self.prepended(base)
+    base.has_many :return_labels, class_name: "Spree::ReturnLabel"
+  end
+
+  Spree::ReturnAuthorization.prepend self
 end

--- a/app/decorators/models/solidus_shipping_labeler/spree/stock_location_decorator.rb
+++ b/app/decorators/models/solidus_shipping_labeler/spree/stock_location_decorator.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
-Spree::StockLocation.class_eval do
+module SolidusShippingLabeler::Spree::StockLocationDecorator
+  module ClassMethods
+    # Shipping destination for returns
+    def return_processing
+      first
+    end
+  end
+
+  def self.prepended(base)
+    base.singleton_class.prepend ClassMethods
+  end
+
   def company
     "Working Title"
   end
@@ -18,8 +29,5 @@ Spree::StockLocation.class_eval do
     }
   end
 
-  # Shipping destination for returns
-  def self.return_processing
-    first
-  end
+  Spree::StockLocation.prepend self
 end

--- a/lib/solidus_shipping_labeler/engine.rb
+++ b/lib/solidus_shipping_labeler/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusShippingLabeler
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 

--- a/solidus_shipping_labeler.gemspec
+++ b/solidus_shipping_labeler.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  s.add_dependency 'solidus_support', '~> 0.4.0'
+  s.add_dependency 'solidus_support', '~> 0.5'
   s.add_dependency 'fedex', '>= 3.6.1'
 
   s.add_development_dependency 'solidus_dev_support'

--- a/spec/features/admin/rma_label_creation_spec.rb
+++ b/spec/features/admin/rma_label_creation_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe "Admin order RMA label creation", js: true do
-  let(:current_user) { FactoryBot.create(:admin_user) }
+  let(:current_user) { FactoryBot.create(:admin_user, :with_api_key) }
 
   let(:order) { FactoryBot.create(:shipped_order) }
   let(:rma) { FactoryBot.create(:return_authorization) }


### PR DESCRIPTION
This PR relaxes solidus_support requirements to `~> 0.5`, makes factories usage compliant with current Solidus master and updates decorators to make them compatible with Rails >= 6.0 preloading.